### PR TITLE
FASTA to table 0.3.0

### DIFF
--- a/Metanodes templates/Manipulation/FASTA to table/.savedWithData
+++ b/Metanodes templates/Manipulation/FASTA to table/.savedWithData
@@ -1,4 +1,4 @@
 Do not delete this file!
 This file serves to indicate that the workflow was written as part of the usual save routine (not exported).
 
-Workflow was last saved by user knimeuser on Thu Feb 21 15:43:36 CET 2019
+Workflow was last saved by user knimeuser on Thu Aug 15 15:08:55 CEST 2019

--- a/Metanodes templates/Manipulation/FASTA to table/Python Source (#50)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/Python Source (#50)/settings.xml
@@ -6,24 +6,24 @@
 <entry key="memory_policy" type="xstring" value="CacheSmallInMemory"/>
 </config>
 <config key="model">
-<entry key="sourceCode" type="xstring" value="from pandas import DataFrame%%00010%%00010%%00010%%00010def get_sequences_from_fasta_file(fasta_path):%%00010%%00009f = open(fasta_path, &quot;r&quot;)%%00010%%00009proteins = {}%%00010%%00009protein_accession = None%%00010%%00009i = 0%%00010%%00009for line in f:%%00010%%00009%%00009if (line[0] == &quot;&gt;&quot;):%%00010%%00009%%00009%%00009i += 1%%00010%%00009%%00009%%00009proteins[&quot;row_&quot; + str(i)] = {%%00010%%00009%%00009%%00009%%00009flow_variables['header_column_name']: line[1:].split(&quot;\n&quot;)[0],%%00010%%00009%%00009%%00009%%00009flow_variables['sequence_column_name']: &quot;&quot;%%00010%%00009%%00009%%00009}%%00010%%00009%%00009elif line.split():%%00010%%00009%%00009%%00009proteins[&quot;row_&quot; + str(i)][flow_variables['sequence_column_name']] += line.split()[0]%%00010%%00009return proteins%%00010%%00010%%00010abs_path = flow_variables['absolute_path']%%00010proteins = get_sequences_from_fasta_file(abs_path)%%00010%%00010%%00010# Create empty table%%00010output_table = DataFrame.from_dict(proteins, orient=&quot;index&quot;)%%00010%%00010"/>
+<entry key="sourceCode" type="xstring" value="from pandas import DataFrame%%00010%%00010def get_sequences_from_fasta_file(fasta_path):%%00010%%00009proteins = []%%00010%%00009protein_accession = None%%00010%%00009i = -1%%00010%%00009with open(fasta_path, &quot;r&quot;) as infile:%%00010%%00009%%00009for line in infile:%%00010%%00009%%00009%%00009if (line[0] == &quot;&gt;&quot;):%%00010%%00009%%00009%%00009%%00009i += 1%%00010%%00009%%00009%%00009%%00009#print(&quot;list&quot;+str(i))%%00010%%00009%%00009%%00009%%00009proteins.append([line[1:].split(&quot;\n&quot;)[0], &quot;&quot;])%%00010%%00009%%00009%%00009elif line.split():%%00010%%00009%%00009%%00009%%00009proteins[i][1] += line.split()[0]%%00010%%00009%%00009return proteins%%00010%%00010abs_path = flow_variables['absolute_path']%%00010proteins = get_sequences_from_fasta_file(abs_path)%%00010%%00010# Create empty table%%00010output_table = DataFrame(proteins)%%00010output_table.columns = [flow_variables['header_column_name'], flow_variables['sequence_column_name']]%%00010"/>
 <entry key="rowLimit" type="xint" value="1000"/>
 <entry key="pythonVersionOption" type="xstring" value="PYTHON3"/>
 <entry key="convertMissingToPython" type="xboolean" value="false"/>
 <entry key="convertMissingFromPython" type="xboolean" value="false"/>
 <entry key="sentinelOption" type="xstring" value="MIN_VAL"/>
 <entry key="sentinelValue" type="xint" value="0"/>
-<entry key="chunkSize" type="xint" value="500000"/>
+<entry key="chunkSize" type="xint" value="50000"/>
 <entry key="python2Command" type="xstring" value=""/>
 <entry key="python3Command" type="xstring" value=""/>
 </config>
 <config key="nodeAnnotation">
-<entry key="text" type="xstring" value="Create table"/>
+<entry key="text" type="xstring" value="Create table%%00010list"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="357"/>
+<entry key="x-coordinate" type="xint" value="389"/>
 <entry key="y-coordinate" type="xint" value="199"/>
-<entry key="width" type="xint" value="126"/>
-<entry key="height" type="xint" value="17"/>
+<entry key="width" type="xint" value="142"/>
+<entry key="height" type="xint" value="34"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
 <entry key="borderColor" type="xint" value="16777215"/>
@@ -32,17 +32,17 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="CONFIGURED"/>
+<entry key="state" type="xstring" value="IDLE"/>
 <entry key="factory" type="xstring" value="org.knime.python2.nodes.source.Python2SourceNodeFactory"/>
 <entry key="node-name" type="xstring" value="Python Source"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Python nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.python2.nodes"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201811291930"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170931"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Python Integration"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.python2.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041252"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904170931"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="Python Source"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/FASTA to table/String Input (#46)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/String Input (#46)/settings.xml
@@ -26,9 +26,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="header column name"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="37"/>
+<entry key="x-coordinate" type="xint" value="29"/>
 <entry key="y-coordinate" type="xint" value="79"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -48,11 +48,11 @@
 <entry key="node-bundle-name" type="xstring" value="KNIME Quick Form Nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.js.quickforms"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170930"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Quick Forms"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.js.quickforms.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904170930"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="String Input"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/FASTA to table/String Input (#47)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/String Input (#47)/settings.xml
@@ -26,9 +26,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="sequence column name"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="191"/>
+<entry key="x-coordinate" type="xint" value="183"/>
 <entry key="y-coordinate" type="xint" value="79"/>
-<entry key="width" type="xint" value="138"/>
+<entry key="width" type="xint" value="155"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -44,11 +44,11 @@
 <entry key="node-bundle-name" type="xstring" value="KNIME Quick Form Nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.js.quickforms"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170930"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Quick Forms"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.js.quickforms.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904170930"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="String Input"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/.savedWithData
+++ b/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/.savedWithData
@@ -1,4 +1,4 @@
 Do not delete this file!
 This file serves to indicate that the workflow was written as part of the usual save routine (not exported).
 
-Workflow was last saved by user knimeuser on Thu Feb 21 15:43:36 CET 2019
+Workflow was last saved by user knimeuser on Thu Aug 15 15:08:55 CEST 2019

--- a/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/Python Edit Variable (#44)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/Python Edit Variable (#44)/settings.xml
@@ -20,9 +20,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="URI to absolute path"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="223"/>
+<entry key="x-coordinate" type="xint" value="215"/>
 <entry key="y-coordinate" type="xint" value="182"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -32,17 +32,17 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="CONFIGURED"/>
+<entry key="state" type="xstring" value="IDLE"/>
 <entry key="factory" type="xstring" value="org.knime.python2.nodes.variables.Python2VariablesNodeFactory"/>
 <entry key="node-name" type="xstring" value="Python Edit Variable"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Python nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.python2.nodes"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201811291930"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170931"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Python Integration"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.python2.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041252"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904170931"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="Python Edit Variable"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/URI Port to Variable (#42)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/URI Port to Variable (#42)/settings.xml
@@ -9,9 +9,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value=""/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="103"/>
+<entry key="x-coordinate" type="xint" value="95"/>
 <entry key="y-coordinate" type="xint" value="182"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -21,7 +21,7 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="CONFIGURED"/>
+<entry key="state" type="xstring" value="IDLE"/>
 <entry key="factory" type="xstring" value="org.knime.base.filehandling.uriporttovariable.URIPortToVariableNodeFactory"/>
 <entry key="node-name" type="xstring" value="URI Port to Variable"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME File Handling Nodes"/>

--- a/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/WrappedNode Input (#45)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/WrappedNode Input (#45)/settings.xml
@@ -35,9 +35,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value=""/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="3"/>
+<entry key="x-coordinate" type="xint" value="-5"/>
 <entry key="y-coordinate" type="xint" value="182"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -47,7 +47,7 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="CONFIGURED"/>
+<entry key="state" type="xstring" value="IDLE"/>
 <config key="nodecontainer_message">
 <entry key="type" type="xstring" value="WARNING"/>
 <entry key="message" type="xstring" value="Outer workflow does not have input data, execute it first"/>
@@ -58,11 +58,11 @@
 <entry key="node-bundle-name" type="xstring" value="KNIME Core API"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.core"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812041251"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Core"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.base.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904171038"/>
 <config key="factory_settings">
 <config key="port_0">
 <entry key="index" type="xint" value="0"/>

--- a/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/WrappedNode Output (#46)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/WrappedNode Output (#46)/settings.xml
@@ -36,9 +36,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value=""/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="357"/>
+<entry key="x-coordinate" type="xint" value="349"/>
 <entry key="y-coordinate" type="xint" value="179"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -48,18 +48,18 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="CONFIGURED"/>
+<entry key="state" type="xstring" value="IDLE"/>
 <entry key="isDeletable" type="xboolean" value="false"/>
 <entry key="factory" type="xstring" value="org.knime.core.node.workflow.virtual.subnode.VirtualSubNodeOutputNodeFactory"/>
 <entry key="node-name" type="xstring" value="WrappedNode Output"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Core API"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.core"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812041251"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Core"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.base.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904171038"/>
 <config key="factory_settings">
 <config key="port_0">
 <entry key="index" type="xint" value="0"/>

--- a/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/settings.xml
@@ -9,9 +9,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value=""/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="197"/>
+<entry key="x-coordinate" type="xint" value="189"/>
 <entry key="y-coordinate" type="xint" value="199"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -21,7 +21,7 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="CONFIGURED"/>
+<entry key="state" type="xstring" value="IDLE"/>
 <entry key="virtual-in-ID" type="xint" value="45"/>
 <config key="inports">
 <config key="inport_0">

--- a/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/workflow.knime
+++ b/Metanodes templates/Manipulation/FASTA to table/URI Port to (#45)/workflow.knime
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns="http://www.knime.org/2008/09/XMLConfig" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.knime.org/2008/09/XMLConfig http://www.knime.org/XMLConfig_2008_09.xsd" key="workflow.knime">
-<entry key="created_by" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="created_by" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="created_by_nightly" type="xboolean" value="false"/>
 <entry key="version" type="xstring" value="3.7.0"/>
 <entry key="name" type="xstring" value="URI Port to absolute path"/>
@@ -25,7 +25,7 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="CONFIGURED"/>
+<entry key="state" type="xstring" value="IDLE"/>
 <config key="workflow_credentials"/>
 <config key="nodes">
 <config key="node_42">
@@ -39,8 +39,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="150"/>
 <entry key="1" type="xint" value="120"/>
-<entry key="2" type="xint" value="77"/>
-<entry key="3" type="xint" value="101"/>
+<entry key="2" type="xint" value="91"/>
+<entry key="3" type="xint" value="97"/>
 </config>
 </config>
 </config>
@@ -55,8 +55,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="270"/>
 <entry key="1" type="xint" value="120"/>
-<entry key="2" type="xint" value="80"/>
-<entry key="3" type="xint" value="101"/>
+<entry key="2" type="xint" value="95"/>
+<entry key="3" type="xint" value="97"/>
 </config>
 </config>
 </config>
@@ -71,8 +71,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="50"/>
 <entry key="1" type="xint" value="120"/>
-<entry key="2" type="xint" value="137"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="168"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -87,8 +87,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="404"/>
 <entry key="1" type="xint" value="117"/>
-<entry key="2" type="xint" value="148"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="181"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>

--- a/Metanodes templates/Manipulation/FASTA to table/WrappedNode Input (#40)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/WrappedNode Input (#40)/settings.xml
@@ -22,10 +22,10 @@
 </config>
 </config>
 <entry key="variable-prefix" type="xstring" isnull="true" value=""/>
-<entry key="sub-node-description" type="xstring" value="Metanode for FASTA files conversion to tabular format.%%00010%%00010Single table is the metanode output with sequence header in its 1st column and seqeunce without spaces in the second column. You can specify the names of the header and sequence columns.%%00010%%00010=================%%00010%%00010Used programs and tools and their respective licenses at the time of the metanode creation. Version numbers and the licenses might differ based on your local installation. Please inspect your local installation and contact us if you can not locate your local version and or license terms.%%00010%%00010KNIME nodes (The KNIME nodes consists of the following GNU GPL 3.0 License. Licence terms are available here: https://www.gnu.org/licenses/gpl.html)%%00010Python 3 (The Python consists of the following Python 3.6 License. Licence terms are available here: https://docs.python.org/3.6/license.html)%%00010Python package Pandas (The Pandas consists of the following BSD License. Licence terms are available here: https://opensource.org/licenses/BSD-3-Clause)%%00010%%00010The metanode was created in KNIME 3.7.0 running inside the docker image (https://hub.docker.com/r/cfprot/knime/), tag 3.7.0a.%%00010%%00010=================%%00010%%00010This version of metanode is available under the GNU GPL 3.0 License, unless stated otherwise. The full version of the license terms is available at https://www.gnu.org/licenses/gpl.html.%%00010Version: 0.2.0 from 2019-02-21%%00010Contact person: Michal Cupak (michal.cupak@ceitec.muni.cz)%%00010More information can be found at https://github.com/OmicsWorkflows/KNIME_metanodes."/>
+<entry key="sub-node-description" type="xstring" value="Metanode for FASTA files conversion to tabular format.%%00010%%00010Single table is the metanode output with sequence header in its 1st column and seqeunce without spaces in the second column. You can specify the names of the header and sequence columns.%%00010%%00010There is currently limitation in size of the database related to the RAM usage.%%00010%%00010=================%%00010%%00010Used programs and tools and their respective licenses at the time of the metanode creation. Version numbers and the licenses might differ based on your local installation. Please inspect your local installation and contact us if you can not locate your local version and or license terms.%%00010%%00010KNIME nodes (The KNIME nodes consists of the following GNU GPL 3.0 License. Licence terms are available here: https://www.gnu.org/licenses/gpl.html)%%00010Python 3 (The Python consists of the following Python 3.6 License. Licence terms are available here: https://docs.python.org/3.6/license.html)%%00010Python package Pandas (The Pandas consists of the following BSD License. Licence terms are available here: https://opensource.org/licenses/BSD-3-Clause)%%00010%%00010The metanode was created in KNIME 3.7.2 running inside the docker image (https://hub.docker.com/r/cfprot/knime/), tag 3.7.2a.%%00010%%00010=================%%00010%%00010This version of metanode is available under the GNU GPL 3.0 License, unless stated otherwise. The full version of the license terms is available at https://www.gnu.org/licenses/gpl.html.%%00010Version: 0.3.0 from 2019-08-15%%00010Contact person: Michal Cupak (michal.cupak@ceitec.muni.cz)%%00010More information can be found at https://github.com/OmicsWorkflows/KNIME_metanodes."/>
 <config key="port-names">
 <entry key="array-size" type="xint" value="1"/>
-<entry key="0" type="xstring" value="Port 1"/>
+<entry key="0" type="xstring" value=""/>
 </config>
 <config key="port-descriptions">
 <entry key="array-size" type="xint" value="1"/>
@@ -44,11 +44,11 @@
 <entry key="node-bundle-name" type="xstring" value="KNIME Core API"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.core"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812041251"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Core"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.base.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904171038"/>
 <config key="factory_settings">
 <config key="port_0">
 <entry key="index" type="xint" value="0"/>

--- a/Metanodes templates/Manipulation/FASTA to table/WrappedNode Output (#41)/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/WrappedNode Output (#41)/settings.xml
@@ -25,7 +25,6 @@
 </config>
 </config>
 <entry key="variable-prefix" type="xstring" isnull="true" value=""/>
-<entry key="sub-node-description" type="xstring" isnull="true" value=""/>
 <config key="port-names">
 <entry key="array-size" type="xint" value="1"/>
 <entry key="0" type="xstring" value="table"/>
@@ -43,11 +42,11 @@
 <entry key="node-bundle-name" type="xstring" value="KNIME Core API"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.core"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812041251"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Core"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.base.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904171038"/>
 <config key="factory_settings">
 <config key="port_0">
 <entry key="index" type="xint" value="0"/>

--- a/Metanodes templates/Manipulation/FASTA to table/settings.xml
+++ b/Metanodes templates/Manipulation/FASTA to table/settings.xml
@@ -10,9 +10,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value=""/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="177"/>
-<entry key="y-coordinate" type="xint" value="479"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="x-coordinate" type="xint" value="469"/>
+<entry key="y-coordinate" type="xint" value="839"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -43,7 +43,7 @@
 </config>
 <config key="workflow_template_information">
 <entry key="role" type="xstring" value="Template"/>
-<entry key="timestamp" type="xstring" value="2019-02-21 15:43:36"/>
+<entry key="timestamp" type="xstring" value="2019-08-15 15:08:54"/>
 <entry key="sourceURI" type="xstring" isnull="true" value=""/>
 <entry key="templateType" type="xstring" value="SubNode"/>
 </config>

--- a/Metanodes templates/Manipulation/FASTA to table/template.knime
+++ b/Metanodes templates/Manipulation/FASTA to table/template.knime
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns="http://www.knime.org/2008/09/XMLConfig" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.knime.org/2008/09/XMLConfig http://www.knime.org/XMLConfig_2008_09.xsd" key="Template">
-<entry key="created_by" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="created_by" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="created_by_nightly" type="xboolean" value="false"/>
 <entry key="version" type="xstring" value="3.7.0"/>
 <config key="workflow_template_information">
 <entry key="role" type="xstring" value="Template"/>
-<entry key="timestamp" type="xstring" value="2019-02-21 15:43:36"/>
+<entry key="timestamp" type="xstring" value="2019-08-15 15:08:54"/>
 <entry key="sourceURI" type="xstring" isnull="true" value=""/>
 <entry key="templateType" type="xstring" value="SubNode"/>
 </config>

--- a/Metanodes templates/Manipulation/FASTA to table/workflow.knime
+++ b/Metanodes templates/Manipulation/FASTA to table/workflow.knime
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns="http://www.knime.org/2008/09/XMLConfig" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.knime.org/2008/09/XMLConfig http://www.knime.org/XMLConfig_2008_09.xsd" key="workflow.knime">
-<entry key="created_by" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="created_by" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="created_by_nightly" type="xboolean" value="false"/>
 <entry key="version" type="xstring" value="3.7.0"/>
 <entry key="name" type="xstring" isnull="true" value=""/>
@@ -39,8 +39,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="44"/>
 <entry key="1" type="xint" value="137"/>
-<entry key="2" type="xint" value="137"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="168"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -53,26 +53,10 @@
 <config key="ui_settings">
 <config key="extrainfo.node.bounds">
 <entry key="array-size" type="xint" value="4"/>
-<entry key="0" type="xint" value="564"/>
-<entry key="1" type="xint" value="137"/>
-<entry key="2" type="xint" value="148"/>
-<entry key="3" type="xint" value="82"/>
-</config>
-</config>
-</config>
-<config key="node_43">
-<entry key="id" type="xint" value="43"/>
-<entry key="node_settings_file" type="xstring" value="Python Source (#43)/settings.xml"/>
-<entry key="node_is_meta" type="xboolean" value="false"/>
-<entry key="node_type" type="xstring" value="NativeNode"/>
-<entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.NodeUIInformation"/>
-<config key="ui_settings">
-<config key="extrainfo.node.bounds">
-<entry key="array-size" type="xint" value="4"/>
-<entry key="0" type="xint" value="404"/>
-<entry key="1" type="xint" value="137"/>
-<entry key="2" type="xint" value="101"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="0" type="xint" value="694"/>
+<entry key="1" type="xint" value="139"/>
+<entry key="2" type="xint" value="181"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -87,8 +71,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="244"/>
 <entry key="1" type="xint" value="137"/>
-<entry key="2" type="xint" value="92"/>
-<entry key="3" type="xint" value="101"/>
+<entry key="2" type="xint" value="114"/>
+<entry key="3" type="xint" value="97"/>
 </config>
 </config>
 </config>
@@ -103,8 +87,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="84"/>
 <entry key="1" type="xint" value="17"/>
-<entry key="2" type="xint" value="81"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="100"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -119,8 +103,24 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="244"/>
 <entry key="1" type="xint" value="17"/>
-<entry key="2" type="xint" value="81"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="100"/>
+<entry key="3" type="xint" value="80"/>
+</config>
+</config>
+</config>
+<config key="node_50">
+<entry key="id" type="xint" value="50"/>
+<entry key="node_settings_file" type="xstring" value="Python Source (#50)/settings.xml"/>
+<entry key="node_is_meta" type="xboolean" value="false"/>
+<entry key="node_type" type="xstring" value="NativeNode"/>
+<entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.NodeUIInformation"/>
+<config key="ui_settings">
+<config key="extrainfo.node.bounds">
+<entry key="array-size" type="xint" value="4"/>
+<entry key="0" type="xint" value="444"/>
+<entry key="1" type="xint" value="137"/>
+<entry key="2" type="xint" value="119"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -133,22 +133,16 @@
 <entry key="destPort" type="xint" value="1"/>
 </config>
 <config key="connection_1">
-<entry key="sourceID" type="xint" value="43"/>
-<entry key="destID" type="xint" value="41"/>
+<entry key="sourceID" type="xint" value="45"/>
+<entry key="destID" type="xint" value="50"/>
 <entry key="sourcePort" type="xint" value="1"/>
-<entry key="destPort" type="xint" value="1"/>
+<entry key="destPort" type="xint" value="0"/>
 <entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.ConnectionUIInformation"/>
 <config key="ui_settings">
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
 </config>
 </config>
 <config key="connection_2">
-<entry key="sourceID" type="xint" value="45"/>
-<entry key="destID" type="xint" value="43"/>
-<entry key="sourcePort" type="xint" value="1"/>
-<entry key="destPort" type="xint" value="0"/>
-</config>
-<config key="connection_3">
 <entry key="sourceID" type="xint" value="46"/>
 <entry key="destID" type="xint" value="47"/>
 <entry key="sourcePort" type="xint" value="1"/>
@@ -158,11 +152,21 @@
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
 </config>
 </config>
-<config key="connection_4">
+<config key="connection_3">
 <entry key="sourceID" type="xint" value="47"/>
 <entry key="destID" type="xint" value="45"/>
 <entry key="sourcePort" type="xint" value="1"/>
 <entry key="destPort" type="xint" value="0"/>
+<entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.ConnectionUIInformation"/>
+<config key="ui_settings">
+<entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
+</config>
+</config>
+<config key="connection_4">
+<entry key="sourceID" type="xint" value="50"/>
+<entry key="destID" type="xint" value="41"/>
+<entry key="sourcePort" type="xint" value="1"/>
+<entry key="destPort" type="xint" value="1"/>
 <entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.ConnectionUIInformation"/>
 <config key="ui_settings">
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>


### PR DESCRIPTION
internally redesigned to be more compatible with bigger databases (fixes #20 for now); there still might be limitation on the database size with extra big databases (e.g. 100GB)