### PR TITLE
Table to FASTA 0.2.0

### DIFF
--- a/Metanodes templates/Manipulation/Table to FASTA/.savedWithData
+++ b/Metanodes templates/Manipulation/Table to FASTA/.savedWithData
@@ -1,4 +1,4 @@
 Do not delete this file!
 This file serves to indicate that the workflow was written as part of the usual save routine (not exported).
 
-Workflow was last saved by user knimeuser on Thu Feb 21 15:53:49 CET 2019
+Workflow was last saved by user knimeuser on Thu Aug 15 21:53:01 CEST 2019

--- a/Metanodes templates/Manipulation/Table to FASTA/Column Appender (#63)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/Column Appender (#63)/settings.xml
@@ -18,17 +18,17 @@
 <entry key="row_key_select" type="xstring" value="Use row keys from FIRST table"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
 <entry key="factory" type="xstring" value="org.knime.base.node.preproc.columnappend.ColumnAppenderNodeFactory"/>
 <entry key="node-name" type="xstring" value="Column Appender"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Base Nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.base"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812031623"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Core"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.base.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904171038"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="Column Appender"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/Column Filter (#61)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/Column Filter (#61)/settings.xml
@@ -47,9 +47,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="selects header column"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="295"/>
+<entry key="x-coordinate" type="xint" value="287"/>
 <entry key="y-coordinate" type="xint" value="219"/>
-<entry key="width" type="xint" value="131"/>
+<entry key="width" type="xint" value="147"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -59,17 +59,17 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
 <entry key="factory" type="xstring" value="org.knime.base.node.preproc.filter.column.DataColumnSpecFilterNodeFactory"/>
 <entry key="node-name" type="xstring" value="Column Filter"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Base Nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.base"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812031623"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Core"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.base.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904171038"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="Column Filter"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/Column Filter (#62)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/Column Filter (#62)/settings.xml
@@ -47,9 +47,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="selects sequence column"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="286"/>
+<entry key="x-coordinate" type="xint" value="278"/>
 <entry key="y-coordinate" type="xint" value="339"/>
-<entry key="width" type="xint" value="148"/>
+<entry key="width" type="xint" value="164"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -59,17 +59,17 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
 <entry key="factory" type="xstring" value="org.knime.base.node.preproc.filter.column.DataColumnSpecFilterNodeFactory"/>
 <entry key="node-name" type="xstring" value="Column Filter"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Base Nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.base"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812031623"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Core"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.base.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904171038"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="Column Filter"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/Column Selection (#57)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/Column Selection (#57)/settings.xml
@@ -29,9 +29,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="Header column selection"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="148"/>
+<entry key="x-coordinate" type="xint" value="139"/>
 <entry key="y-coordinate" type="xint" value="79"/>
-<entry key="width" type="xint" value="144"/>
+<entry key="width" type="xint" value="162"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -41,17 +41,17 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
 <entry key="factory" type="xstring" value="org.knime.js.base.node.quickform.selection.column.ColumnSelectionQuickFormNodeFactory"/>
 <entry key="node-name" type="xstring" value="Column Selection"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Quick Form Nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.js.quickforms"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170930"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Quick Forms"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.js.quickforms.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904170930"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="Column Selection"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/Column Selection (#58)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/Column Selection (#58)/settings.xml
@@ -29,9 +29,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="Sequence column selection"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="140"/>
+<entry key="x-coordinate" type="xint" value="131"/>
 <entry key="y-coordinate" type="xint" value="479"/>
-<entry key="width" type="xint" value="160"/>
+<entry key="width" type="xint" value="178"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -41,17 +41,17 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
 <entry key="factory" type="xstring" value="org.knime.js.base.node.quickform.selection.column.ColumnSelectionQuickFormNodeFactory"/>
 <entry key="node-name" type="xstring" value="Column Selection"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Quick Form Nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.js.quickforms"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170930"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Quick Forms"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.js.quickforms.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904170930"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="Column Selection"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/File Chooser (#59)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/File Chooser (#59)/settings.xml
@@ -39,9 +39,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="Target directory"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="297"/>
+<entry key="x-coordinate" type="xint" value="289"/>
 <entry key="y-coordinate" type="xint" value="79"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -51,17 +51,21 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
+<config key="nodecontainer_message">
+<entry key="type" type="xstring" value="WARNING"/>
+<entry key="message" type="xstring" value="Outer workflow does not have input data, execute it first"/>
+</config>
 <entry key="factory" type="xstring" value="org.knime.js.base.node.quickform.input.filechooser.FileChooserQuickFormNodeFactory"/>
 <entry key="node-name" type="xstring" value="File Chooser"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Quick Form Nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.js.quickforms"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170930"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Quick Forms"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.js.quickforms.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904170930"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="File Chooser"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/Python Script _1_1_ (#64)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/Python Script _1_1_ (#64)/settings.xml
@@ -6,7 +6,7 @@
 <entry key="memory_policy" type="xstring" value="CacheSmallInMemory"/>
 </config>
 <config key="model">
-<entry key="sourceCode" type="xstring" value="import textwrap%%00010import os.path%%00010%%00010# gets absolute path to the file from the target folder and the filename%%00010absolute_path_to_file = os.path.join(flow_variables['file_path'], flow_variables['fasta_file_name'])%%00010%%00010fasta_text = &quot;&quot;%%00010%%00010# iterates through the provided table rows and wraps seqeunce to a multiline string and combines it with the header in the next step%%00010for index, row in input_table.iterrows():%%00010    sequence_multiline = &quot;&quot;%%00010    sequence_multiline = textwrap.fill(row[flow_variables['sequence_column']], width=60)%%00010    fasta_text += &quot;&gt;&quot; + row[flow_variables['header_column']] + &quot;\n&quot; + sequence_multiline + &quot;\n&quot;%%00010%%00010# opens the specified file (or creates a new one in case it does not exist) and writes the fasta text into it%%00010# the file is overwritten!%%00010f = open(absolute_path_to_file, &quot;w&quot;)%%00010f.write(fasta_text)%%00010f.close()%%00010%%00010# outputs also the path to the created fasta file for further use in the workflow%%00010import pandas%%00010output_table = pandas.DataFrame({&quot;path&quot;: [absolute_path_to_file]})%%00010"/>
+<entry key="sourceCode" type="xstring" value="import textwrap%%00010import os.path%%00010%%00010# gets absolute path to the file from the target folder and the filename%%00010absolute_path_to_file = os.path.join(flow_variables['file_path'], flow_variables['fasta_file_name'])%%00010%%00010fasta_text = &quot;&quot;%%00010%%00010# resets the already present file if it is the case%%00010open(absolute_path_to_file, 'w')%%00010%%00010%%00010# iterates through the provided table rows and wraps seqeunce to a multiline string and combines it with the header in the next step%%00010with open(absolute_path_to_file, 'a') as file:%%00010%%00009for index, row in input_table.iterrows():%%00010%%00009%%00009fasta_text = &quot;&quot;%%00010%%00009%%00009sequence_multiline = &quot;&quot;%%00010%%00009%%00009sequence_multiline = textwrap.fill(row[flow_variables['sequence_column']], width=60)%%00010%%00009%%00009fasta_text += &quot;&gt;&quot; + row[flow_variables['header_column']] + &quot;\n&quot; + sequence_multiline + &quot;\n&quot;%%00010%%00009%%00009file.write(fasta_text)%%00010%%00010# opens the specified file (or creates a new one in case it does not exist) and writes the fasta text into it%%00010# the file is overwritten!%%00010#f = open(absolute_path_to_file, &quot;w&quot;)%%00010#f.write(fasta_text)%%00010#f.close()%%00010%%00010# outputs also the path to the created fasta file for further use in the workflow%%00010import pandas%%00010output_table = pandas.DataFrame({&quot;path&quot;: [absolute_path_to_file]})%%00010"/>
 <entry key="rowLimit" type="xint" value="1000"/>
 <entry key="pythonVersionOption" type="xstring" value="PYTHON3"/>
 <entry key="convertMissingToPython" type="xboolean" value="false"/>
@@ -18,17 +18,17 @@
 <entry key="python3Command" type="xstring" value=""/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
 <entry key="factory" type="xstring" value="org.knime.python2.nodes.script.Python2ScriptNodeFactory"/>
 <entry key="node-name" type="xstring" value="Python Script (1⇒1)"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Python nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.python2.nodes"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201811291930"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170931"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Python Integration"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.python2.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041252"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904170931"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="Python Script (1⇒1)"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/String Input (#60)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/String Input (#60)/settings.xml
@@ -26,9 +26,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="fasta file name with extension"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="573"/>
+<entry key="x-coordinate" type="xint" value="561"/>
 <entry key="y-coordinate" type="xint" value="79"/>
-<entry key="width" type="xint" value="174"/>
+<entry key="width" type="xint" value="198"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -38,17 +38,17 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
 <entry key="factory" type="xstring" value="org.knime.js.base.node.quickform.input.string.StringInputQuickFormNodeFactory"/>
 <entry key="node-name" type="xstring" value="String Input"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Quick Form Nodes"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.js.quickforms"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170930"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Quick Forms"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.js.quickforms.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812040932"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904170930"/>
 <config key="factory_settings"/>
 <entry key="name" type="xstring" value="String Input"/>
 <entry key="hasContent" type="xboolean" value="false"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/URL to File Path _Variable_ (#56)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/URL to File Path _Variable_ (#56)/settings.xml
@@ -11,28 +11,28 @@
 <entry key="EnabledStatus" type="xboolean" value="true"/>
 </config>
 <entry key="VariableName" type="xstring" value="fasta_file_directory"/>
-<config key="AddPrefixToVariable_Internals">
-<entry key="SettingsModelID" type="xstring" value="SMID_boolean"/>
-<entry key="EnabledStatus" type="xboolean" value="true"/>
-</config>
-<entry key="AddPrefixToVariable" type="xboolean" value="false"/>
-<config key="FailOnInvalidSyntax_Internals">
-<entry key="SettingsModelID" type="xstring" value="SMID_boolean"/>
-<entry key="EnabledStatus" type="xboolean" value="true"/>
-</config>
-<entry key="FailOnInvalidSyntax" type="xboolean" value="false"/>
 <config key="FailOnInvalidLocation_Internals">
 <entry key="SettingsModelID" type="xstring" value="SMID_boolean"/>
 <entry key="EnabledStatus" type="xboolean" value="true"/>
 </config>
 <entry key="FailOnInvalidLocation" type="xboolean" value="false"/>
+<config key="FailOnInvalidSyntax_Internals">
+<entry key="SettingsModelID" type="xstring" value="SMID_boolean"/>
+<entry key="EnabledStatus" type="xboolean" value="true"/>
+</config>
+<entry key="FailOnInvalidSyntax" type="xboolean" value="false"/>
+<config key="AddPrefixToVariable_Internals">
+<entry key="SettingsModelID" type="xstring" value="SMID_boolean"/>
+<entry key="EnabledStatus" type="xboolean" value="true"/>
+</config>
+<entry key="AddPrefixToVariable" type="xboolean" value="false"/>
 </config>
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value="gets absolute path"/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="437"/>
+<entry key="x-coordinate" type="xint" value="429"/>
 <entry key="y-coordinate" type="xint" value="79"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -42,7 +42,7 @@
 <config key="styles"/>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
 <entry key="factory" type="xstring" value="org.knime.base.filehandling.urltofilepathvariable.UrlToFilePathVariableNodeFactory"/>
 <entry key="node-name" type="xstring" value="URL to File Path (Variable)"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME File Handling Nodes"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/WrappedNode Input (#48)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/WrappedNode Input (#48)/settings.xml
@@ -22,7 +22,7 @@
 </config>
 </config>
 <entry key="variable-prefix" type="xstring" isnull="true" value=""/>
-<entry key="sub-node-description" type="xstring" value="Metanode for creation of FASTA file based on the two specified columns containing header and sequence.%%00010%%00010Sequences strings are wrapped to have 60 letters on single sequence line.%%00010%%00010=================%%00010%%00010Used programs and tools and their respective licenses at the time of the metanode creation. Version numbers and the licenses might differ based on your local installation. Please inspect your local installation and contact us if you can not locate your local version and or license terms.%%00010%%00010KNIME nodes (The KNIME nodes consists of the following GNU GPL 3.0 License. Licence terms are available here: https://www.gnu.org/licenses/gpl.html)%%00010Python 3 (The Python consists of the following Python 3.6 License. Licence terms are available here: https://docs.python.org/3.6/license.html)%%00010Python package Pandas (The Pandas consists of the following BSD License. Licence terms are available here: https://opensource.org/licenses/BSD-3-Clause)%%00010%%00010The metanode was created in KNIME 3.7.0 running inside the docker image (https://hub.docker.com/r/cfprot/knime/), tag 3.7.0a.%%00010%%00010=================%%00010%%00010This version of metanode is available under the GNU GPL 3.0 License, unless stated otherwise. The full version of the license terms is available at https://www.gnu.org/licenses/gpl.html.%%00010Version: 0.1.0 from 2019-02-21%%00010Contact person: Michal Cupak (michal.cupak@ceitec.muni.cz)%%00010More information can be found at https://github.com/OmicsWorkflows/KNIME_metanodes."/>
+<entry key="sub-node-description" type="xstring" value="Metanode for creation of FASTA file based on the two specified columns containing header and sequence.%%00010%%00010Sequences strings are wrapped to have 60 letters on single sequence line.%%00010%%00010There might be limitation in the processable tabular database size because it is read into RAM and on some systems the RAM may not be sufficient.%%00010%%00010=================%%00010%%00010Used programs and tools and their respective licenses at the time of the metanode creation. Version numbers and the licenses might differ based on your local installation. Please inspect your local installation and contact us if you can not locate your local version and or license terms.%%00010%%00010KNIME nodes (The KNIME nodes consists of the following GNU GPL 3.0 License. Licence terms are available here: https://www.gnu.org/licenses/gpl.html)%%00010Python 3 (The Python consists of the following Python 3.6 License. Licence terms are available here: https://docs.python.org/3.6/license.html)%%00010Python package Pandas (The Pandas consists of the following BSD License. Licence terms are available here: https://opensource.org/licenses/BSD-3-Clause)%%00010%%00010The metanode was created in KNIME 3.7.2 running inside the docker image (https://hub.docker.com/r/cfprot/knime/), tag 3.7.2a.%%00010%%00010=================%%00010%%00010This version of metanode is available under the GNU GPL 3.0 License, unless stated otherwise. The full version of the license terms is available at https://www.gnu.org/licenses/gpl.html.%%00010Version: 0.2.0 from 2019-08-15%%00010Contact person: Michal Cupak (michal.cupak@ceitec.muni.cz)%%00010More information can be found at https://github.com/OmicsWorkflows/KNIME_metanodes."/>
 <config key="port-names">
 <entry key="array-size" type="xint" value="1"/>
 <entry key="0" type="xstring" value="Port 1"/>
@@ -33,18 +33,22 @@
 </config>
 </config>
 <entry key="customDescription" type="xstring" isnull="true" value=""/>
-<entry key="state" type="xstring" value="IDLE"/>
+<entry key="state" type="xstring" value="CONFIGURED"/>
+<config key="nodecontainer_message">
+<entry key="type" type="xstring" value="WARNING"/>
+<entry key="message" type="xstring" value="Outer workflow does not have input data, execute it first"/>
+</config>
 <entry key="isDeletable" type="xboolean" value="false"/>
 <entry key="factory" type="xstring" value="org.knime.core.node.workflow.virtual.subnode.VirtualSubNodeInputNodeFactory"/>
 <entry key="node-name" type="xstring" value="WrappedNode Input"/>
 <entry key="node-bundle-name" type="xstring" value="KNIME Core API"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.core"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812041251"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Core"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.base.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904171038"/>
 <config key="factory_settings">
 <config key="port_0">
 <entry key="index" type="xint" value="0"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/WrappedNode Output (#54)/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/WrappedNode Output (#54)/settings.xml
@@ -39,11 +39,11 @@
 <entry key="node-bundle-name" type="xstring" value="KNIME Core API"/>
 <entry key="node-bundle-symbolic-name" type="xstring" value="org.knime.core"/>
 <entry key="node-bundle-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-bundle-version" type="xstring" value="3.7.0.v201812041251"/>
+<entry key="node-bundle-version" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="node-feature-name" type="xstring" value="KNIME Core"/>
 <entry key="node-feature-symbolic-name" type="xstring" value="org.knime.features.base.feature.group"/>
 <entry key="node-feature-vendor" type="xstring" value="KNIME AG, Zurich, Switzerland"/>
-<entry key="node-feature-version" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="node-feature-version" type="xstring" value="3.7.2.v201904171038"/>
 <config key="factory_settings">
 <config key="port_0">
 <entry key="index" type="xint" value="0"/>

--- a/Metanodes templates/Manipulation/Table to FASTA/settings.xml
+++ b/Metanodes templates/Manipulation/Table to FASTA/settings.xml
@@ -10,9 +10,9 @@
 <config key="nodeAnnotation">
 <entry key="text" type="xstring" value=""/>
 <entry key="bgcolor" type="xint" value="16777215"/>
-<entry key="x-coordinate" type="xint" value="377"/>
-<entry key="y-coordinate" type="xint" value="479"/>
-<entry key="width" type="xint" value="126"/>
+<entry key="x-coordinate" type="xint" value="689"/>
+<entry key="y-coordinate" type="xint" value="839"/>
+<entry key="width" type="xint" value="142"/>
 <entry key="height" type="xint" value="17"/>
 <entry key="alignment" type="xstring" value="CENTER"/>
 <entry key="borderSize" type="xint" value="0"/>
@@ -43,7 +43,7 @@
 </config>
 <config key="workflow_template_information">
 <entry key="role" type="xstring" value="Template"/>
-<entry key="timestamp" type="xstring" value="2019-02-21 15:53:49"/>
+<entry key="timestamp" type="xstring" value="2019-08-15 21:53:01"/>
 <entry key="sourceURI" type="xstring" isnull="true" value=""/>
 <entry key="templateType" type="xstring" value="SubNode"/>
 </config>

--- a/Metanodes templates/Manipulation/Table to FASTA/template.knime
+++ b/Metanodes templates/Manipulation/Table to FASTA/template.knime
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns="http://www.knime.org/2008/09/XMLConfig" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.knime.org/2008/09/XMLConfig http://www.knime.org/XMLConfig_2008_09.xsd" key="Template">
-<entry key="created_by" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="created_by" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="created_by_nightly" type="xboolean" value="false"/>
 <entry key="version" type="xstring" value="3.7.0"/>
 <config key="workflow_template_information">
 <entry key="role" type="xstring" value="Template"/>
-<entry key="timestamp" type="xstring" value="2019-02-21 15:53:49"/>
+<entry key="timestamp" type="xstring" value="2019-08-15 21:53:01"/>
 <entry key="sourceURI" type="xstring" isnull="true" value=""/>
 <entry key="templateType" type="xstring" value="SubNode"/>
 </config>

--- a/Metanodes templates/Manipulation/Table to FASTA/workflow.knime
+++ b/Metanodes templates/Manipulation/Table to FASTA/workflow.knime
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns="http://www.knime.org/2008/09/XMLConfig" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.knime.org/2008/09/XMLConfig http://www.knime.org/XMLConfig_2008_09.xsd" key="workflow.knime">
-<entry key="created_by" type="xstring" value="3.7.0.v201812041331"/>
+<entry key="created_by" type="xstring" value="3.7.2.v201904170949"/>
 <entry key="created_by_nightly" type="xboolean" value="false"/>
 <entry key="version" type="xstring" value="3.7.0"/>
 <entry key="name" type="xstring" isnull="true" value=""/>
@@ -39,8 +39,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="24"/>
 <entry key="1" type="xint" value="217"/>
-<entry key="2" type="xint" value="137"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="168"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -55,24 +55,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="824"/>
 <entry key="1" type="xint" value="217"/>
-<entry key="2" type="xint" value="90"/>
-<entry key="3" type="xint" value="82"/>
-</config>
-</config>
-</config>
-<config key="node_51">
-<entry key="id" type="xint" value="51"/>
-<entry key="node_settings_file" type="xstring" value="Python Script _1_1_ (#51)/settings.xml"/>
-<entry key="node_is_meta" type="xboolean" value="false"/>
-<entry key="node_type" type="xstring" value="NativeNode"/>
-<entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.NodeUIInformation"/>
-<config key="ui_settings">
-<config key="extrainfo.node.bounds">
-<entry key="array-size" type="xint" value="4"/>
-<entry key="0" type="xint" value="704"/>
-<entry key="1" type="xint" value="217"/>
-<entry key="2" type="xint" value="134"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="107"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -87,8 +71,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="924"/>
 <entry key="1" type="xint" value="217"/>
-<entry key="2" type="xint" value="77"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="91"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -103,8 +87,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="1044"/>
 <entry key="1" type="xint" value="217"/>
-<entry key="2" type="xint" value="148"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="181"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -119,8 +103,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="484"/>
 <entry key="1" type="xint" value="17"/>
-<entry key="2" type="xint" value="100"/>
-<entry key="3" type="xint" value="101"/>
+<entry key="2" type="xint" value="125"/>
+<entry key="3" type="xint" value="97"/>
 </config>
 </config>
 </config>
@@ -135,8 +119,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="204"/>
 <entry key="1" type="xint" value="17"/>
-<entry key="2" type="xint" value="123"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="144"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -151,8 +135,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="204"/>
 <entry key="1" type="xint" value="417"/>
-<entry key="2" type="xint" value="123"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="144"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -167,8 +151,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="344"/>
 <entry key="1" type="xint" value="17"/>
-<entry key="2" type="xint" value="88"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="103"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -183,8 +167,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="644"/>
 <entry key="1" type="xint" value="17"/>
-<entry key="2" type="xint" value="81"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="100"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -199,8 +183,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="344"/>
 <entry key="1" type="xint" value="157"/>
-<entry key="2" type="xint" value="94"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="112"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -215,8 +199,8 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="344"/>
 <entry key="1" type="xint" value="277"/>
-<entry key="2" type="xint" value="94"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="112"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -231,8 +215,24 @@
 <entry key="array-size" type="xint" value="4"/>
 <entry key="0" type="xint" value="504"/>
 <entry key="1" type="xint" value="217"/>
-<entry key="2" type="xint" value="126"/>
-<entry key="3" type="xint" value="82"/>
+<entry key="2" type="xint" value="148"/>
+<entry key="3" type="xint" value="80"/>
+</config>
+</config>
+</config>
+<config key="node_64">
+<entry key="id" type="xint" value="64"/>
+<entry key="node_settings_file" type="xstring" value="Python Script _1_1_ (#64)/settings.xml"/>
+<entry key="node_is_meta" type="xboolean" value="false"/>
+<entry key="node_type" type="xstring" value="NativeNode"/>
+<entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.NodeUIInformation"/>
+<config key="ui_settings">
+<config key="extrainfo.node.bounds">
+<entry key="array-size" type="xint" value="4"/>
+<entry key="0" type="xint" value="664"/>
+<entry key="1" type="xint" value="217"/>
+<entry key="2" type="xint" value="163"/>
+<entry key="3" type="xint" value="80"/>
 </config>
 </config>
 </config>
@@ -289,22 +289,12 @@
 </config>
 </config>
 <config key="connection_5">
-<entry key="sourceID" type="xint" value="51"/>
-<entry key="destID" type="xint" value="50"/>
-<entry key="sourcePort" type="xint" value="1"/>
-<entry key="destPort" type="xint" value="1"/>
-<entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.ConnectionUIInformation"/>
-<config key="ui_settings">
-<entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
-</config>
-</config>
-<config key="connection_6">
 <entry key="sourceID" type="xint" value="52"/>
 <entry key="destID" type="xint" value="54"/>
 <entry key="sourcePort" type="xint" value="1"/>
 <entry key="destPort" type="xint" value="1"/>
 </config>
-<config key="connection_7">
+<config key="connection_6">
 <entry key="sourceID" type="xint" value="56"/>
 <entry key="destID" type="xint" value="60"/>
 <entry key="sourcePort" type="xint" value="1"/>
@@ -314,7 +304,7 @@
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
 </config>
 </config>
-<config key="connection_8">
+<config key="connection_7">
 <entry key="sourceID" type="xint" value="57"/>
 <entry key="destID" type="xint" value="61"/>
 <entry key="sourcePort" type="xint" value="1"/>
@@ -324,7 +314,7 @@
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
 </config>
 </config>
-<config key="connection_9">
+<config key="connection_8">
 <entry key="sourceID" type="xint" value="58"/>
 <entry key="destID" type="xint" value="62"/>
 <entry key="sourcePort" type="xint" value="1"/>
@@ -334,7 +324,7 @@
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
 </config>
 </config>
-<config key="connection_10">
+<config key="connection_9">
 <entry key="sourceID" type="xint" value="59"/>
 <entry key="destID" type="xint" value="56"/>
 <entry key="sourcePort" type="xint" value="0"/>
@@ -344,9 +334,9 @@
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
 </config>
 </config>
-<config key="connection_11">
+<config key="connection_10">
 <entry key="sourceID" type="xint" value="60"/>
-<entry key="destID" type="xint" value="51"/>
+<entry key="destID" type="xint" value="64"/>
 <entry key="sourcePort" type="xint" value="1"/>
 <entry key="destPort" type="xint" value="0"/>
 <entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.ConnectionUIInformation"/>
@@ -354,7 +344,7 @@
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
 </config>
 </config>
-<config key="connection_12">
+<config key="connection_11">
 <entry key="sourceID" type="xint" value="61"/>
 <entry key="destID" type="xint" value="63"/>
 <entry key="sourcePort" type="xint" value="1"/>
@@ -364,7 +354,7 @@
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
 </config>
 </config>
-<config key="connection_13">
+<config key="connection_12">
 <entry key="sourceID" type="xint" value="62"/>
 <entry key="destID" type="xint" value="63"/>
 <entry key="sourcePort" type="xint" value="1"/>
@@ -374,9 +364,19 @@
 <entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
 </config>
 </config>
-<config key="connection_14">
+<config key="connection_13">
 <entry key="sourceID" type="xint" value="63"/>
-<entry key="destID" type="xint" value="51"/>
+<entry key="destID" type="xint" value="64"/>
+<entry key="sourcePort" type="xint" value="1"/>
+<entry key="destPort" type="xint" value="1"/>
+<entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.ConnectionUIInformation"/>
+<config key="ui_settings">
+<entry key="extrainfo.conn.bendpoints_size" type="xint" value="0"/>
+</config>
+</config>
+<config key="connection_14">
+<entry key="sourceID" type="xint" value="64"/>
+<entry key="destID" type="xint" value="50"/>
 <entry key="sourcePort" type="xint" value="1"/>
 <entry key="destPort" type="xint" value="1"/>
 <entry key="ui_classname" type="xstring" value="org.knime.core.node.workflow.ConnectionUIInformation"/>


### PR DESCRIPTION
internally redesigned to be more compatible with bigger databases (fixes #21 for now); there still might be limitation on the tabular format database size because of reading into RAM